### PR TITLE
Tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 Guardnode daemon responding to client chain coordinator challenges and generating alerts for misbehaviour on the chain.
 
+
 ## Instructions
 
 ### Running
@@ -9,6 +10,7 @@ Guardnode daemon responding to client chain coordinator challenges and generatin
 1. `pip3 install -r requirements.txt`
 2. `python3 setup.py build && python3 setup.py install`
 3. Run `./run_guardnode` or `python3 -m guardnode` providing the required arguments:
+
 
 ### Configuration arguments
 
@@ -22,35 +24,7 @@ Guardnode daemon responding to client chain coordinator challenges and generatin
 - `--bidpubkey`: Guardnode winning bid public key
 - `--challengehost`: Challenge host address
 
-### Demo
 
-The following is a tutorial to see the Guardnode in action without having to run a coordinator instance. First run the coordinator [demo script](https://github.com/commerceblock/coordinator/blob/master/scripts/demo.sh) which generates a request and bid on for that request on a mock service chain.
-
-Next, in a separate terminal window, execute the following replacing `$txid` with a bid txid produced by the demo script above.
-
-```bash
-./run_guardnode --rpcuser user1 --rpcpassword password1 --bidpubkey 029aaa76fcf7b8012041c6b4375ad476408344d842000087aa93c5a33f65d50d92 --nodelogfile $HOME/co-client-dir/ocean_test/debug.log --bidtxid $txid
-```
-We can now send a CHALLENGE asset transaction and watch the guardnode react. In the first terminal window execute:
-
-```bash
-alias ocn='/$HOME/ocean/src/ocean-cli -datadir=$HOME/co-client-dir'
-
-ocn sendtoaddress $(ocn getnewaddress) 1 "" "" false "CHALLENGE"
-
-ocn generate 1
-```
-
-As there is no connection to a coordinator we get an error message but the would-be message is displayed. Guardnode sends their bid txid to identify themselves, the challenge tx hash and a signature to coordinator as a response to the challenge and thus prove their active watching of the client chain.
-
-### Demo with coordinator
-
-To run a demo along with the [coordinator](https://github.com/commerceblock/coordinator) daemon execute the following replacing `$txid` with the txid produced by the coordinator [demo script](https://github.com/commerceblock/coordinator/blob/master/scripts/demo.sh):
-
-```bash
-./run_guardnode --rpcuser user1 --rpcpassword password1 --bidpubkey 029aaa76fcf7b8012041c6b4375ad476408344d842000087aa93c5a33f65d50d92 --nodelogfile $HOME/co-client-dir/ocean_test/debug.log --bidtxid $txid
-```
-This time the coordinator receives the message
 ### Running services with docker-compose
 
 Clone data directories
@@ -107,4 +81,4 @@ docker-compose \
 
 ### Docs
 
-For more details check the [guardnode guide](https://commerceblock.readthedocs.io/en/latest/guardnode-guide/index.html).
+For more details and a demo check the [guardnode guide](https://commerceblock.readthedocs.io/en/latest/guardnode-guide/index.html).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Guardnode
 
-Guardnode daemon responding to client chain coordinator challenges and generating alerts for misbehavior on the chain.
+Guardnode daemon responding to client chain coordinator challenges and generating alerts for misbehaviour on the chain.
 
 ## Instructions
 
@@ -8,9 +8,9 @@ Guardnode daemon responding to client chain coordinator challenges and generatin
 
 1. `pip3 install -r requirements.txt`
 2. `python3 setup.py build && python3 setup.py install`
-3. Run `./run_guardnode` or `python3 -m guardnode` providing the arguments required
+3. Run `./run_guardnode` or `python3 -m guardnode` providing the required arguments:
 
-### Congifuration arguments
+### Configuration arguments
 
 - `--rpcconnect`: Client RPC host
 - `--rpcport`: Client RPC port
@@ -21,16 +21,36 @@ Guardnode daemon responding to client chain coordinator challenges and generatin
 - `--bidtxid`: Guardnode winning bid txid
 - `--bidpubkey`: Guardnode winning bid public key
 - `--challengehost`: Challenge host address
-- `--challengeasset`: Challenge asset hash
 
 ### Demo
 
-To run a demo along with the [coordinator](https://github.com/commerceblock/coordinator) daemon execute the following replacing `$txid` with the txid produced by the coordinator [demo script](https://github.com/commerceblock/coordinator/scripts/demo.sh):
+The following is a tutorial to see the Guardnode in action without having to run a coordinator instance. First run the coordinator [demo script](https://github.com/commerceblock/coordinator/blob/master/scripts/demo.sh) which generates a request and bid on for that request on a mock service chain.
+
+Next, in a separate terminal window, execute the following replacing `$txid` with a bid txid produced by the demo script above.
 
 ```bash
-./run_guardnode --rpcuser user1 --rpcpassword password1 --bidpubkey 029aaa76fcf7b8012041c6b4375ad476408344d842000087aa93c5a33f65d50d92 --challengeasset 73be00507b15f79efccd0184b7ca8367372dfd5334ae8991a492f5f354073c88 --bidtxid $txid
+./run_guardnode --rpcuser user1 --rpcpassword password1 --bidpubkey 029aaa76fcf7b8012041c6b4375ad476408344d842000087aa93c5a33f65d50d92 --nodelogfile $HOME/co-client-dir/ocean_test/debug.log --bidtxid $txid
+```
+We can now send a CHALLENGE asset transaction and watch the guardnode react. In the first terminal window execute:
+
+```bash
+alias ocn='/$HOME/ocean/src/ocean-cli -datadir=$HOME/co-client-dir'
+
+ocn sendtoaddress $(ocn getnewaddress) 1 "" "" false "CHALLENGE"
+
+ocn generate 1
 ```
 
+As there is no connection to a coordinator we get an error message but the would-be message is displayed. Guardnode sends their bid txid to identify themselves, the challenge tx hash and a signature to coordinator as a response to the challenge and thus prove their active watching of the client chain.
+
+### Demo with coordinator
+
+To run a demo along with the [coordinator](https://github.com/commerceblock/coordinator) daemon execute the following replacing `$txid` with the txid produced by the coordinator [demo script](https://github.com/commerceblock/coordinator/blob/master/scripts/demo.sh):
+
+```bash
+./run_guardnode --rpcuser user1 --rpcpassword password1 --bidpubkey 029aaa76fcf7b8012041c6b4375ad476408344d842000087aa93c5a33f65d50d92 --nodelogfile $HOME/co-client-dir/ocean_test/debug.log --bidtxid $txid
+```
+This time the coordinator receives the message
 ### Running services with docker-compose
 
 Clone data directories
@@ -48,7 +68,7 @@ docker-compose \
     -f contrib/docker-compose/cb-guardnode-testnet.yml \
     up -d ocean
 ```
-    
+
 Start guardnode:
 
 ```console
@@ -66,7 +86,7 @@ docker-compose \
     -f contrib/docker-compose/cb-guardnode-testnet.yml \
     ps
 ```
-    
+
 Check ocean logs:
 
 ```console

--- a/contrib/docker-compose/cb-guardnode-testnet.yml
+++ b/contrib/docker-compose/cb-guardnode-testnet.yml
@@ -11,7 +11,6 @@ services:
         --rpcconnect ocean
         --rpcport 7043
         --bidpubkey
-        --challengeasset b8feee98a9ffdc4434269ab1c8ecb96fef920013e6eac0410ff1565373e0b658
         --challengehost https://coordinator.testnet.commerceblock.com:10005
         --nodeaddrprefix 235
         --bidtxid

--- a/guardnode/challenge.py
+++ b/guardnode/challenge.py
@@ -72,7 +72,7 @@ class Challenge(DaemonThread):
             r = requests.post(self.url, data=data, headers=headers)
         except Exception as e:
             self.logger.error(e)
-            self.logger.error("Could not connect to coordinator to send bid tx data:\n{}".format(data))
+            self.logger.error("Could not connect to coordinator to send response data:\n{}".format(data))
             return
 
         self.logger.info("response sent\nsignature:\n{}\ntxid:\n{}".format(sig_hex, txid))

--- a/guardnode/challenge.py
+++ b/guardnode/challenge.py
@@ -21,6 +21,13 @@ def asset_in_block(ocean, asset, block_height):
                 return txid
     return None
 
+def get_challenge_asset(ocean):
+    issuances = ocean.listissuances()
+    for asset in issuances:
+        if asset['assetlabel'] == "CHALLENGE":
+            return asset['asset']
+    return False
+
 class Challenge(DaemonThread):
     def __init__(self, args):
         super().__init__()
@@ -31,12 +38,12 @@ class Challenge(DaemonThread):
         logging.getLogger("BitcoinRPC")
         self.logger = logging.getLogger("Challenge")
 
-        # test valid asset hash
-        util.assert_is_hash_string(self.args.challengeasset)
-        self.rev_challengeasset = util.hex_str_rev_hex_str(self.args.challengeasset)
-        if asset_in_block(self.ocean, self.rev_challengeasset, 0) == None:
-            self.logger.error("Asset {} not found in genesis block".format(self.args.challengeasset))
+        # get challenge asset hash
+        self.args.challengeasset = get_challenge_asset(self.ocean)
+        if self.args.challengeasset == False:
+            self.logger.error("No Challenge asset found in client chain")
             sys.exit(1)
+        self.rev_challengeasset = util.hex_str_rev_hex_str(self.args.challengeasset)
 
         # test valid bid txid
         util.assert_is_hash_string(self.args.bidtxid)
@@ -61,7 +68,12 @@ class Challenge(DaemonThread):
         data = '{{"txid": "{}", "pubkey": "{}", "hash": "{}", "sig": "{}"}}'.\
             format(self.args.bidtxid, self.args.bidpubkey, txid, sig_hex)
         headers = {'content-type': 'application/json', 'Accept-Charset': 'UTF-8'}
-        r = requests.post(self.url, data=data, headers=headers)
+        try:
+            r = requests.post(self.url, data=data, headers=headers)
+        except Exception as e:
+            self.logger.error(e)
+            self.logger.error("Could not connect to coordinator to send bid tx data:\n{}".format(data))
+            return
 
         self.logger.info("response sent\nsignature:\n{}\ntxid:\n{}".format(sig_hex, txid))
         if r.status_code != 200:

--- a/guardnode/challenge.py
+++ b/guardnode/challenge.py
@@ -26,7 +26,8 @@ def get_challenge_asset(ocean):
     for asset in issuances:
         if asset['assetlabel'] == "CHALLENGE":
             return asset['asset']
-    return False
+    self.logger.error("No Challenge asset found in client chain")
+    sys.exit(1)
 
 class Challenge(DaemonThread):
     def __init__(self, args):
@@ -40,9 +41,6 @@ class Challenge(DaemonThread):
 
         # get challenge asset hash
         self.args.challengeasset = get_challenge_asset(self.ocean)
-        if self.args.challengeasset == False:
-            self.logger.error("No Challenge asset found in client chain")
-            sys.exit(1)
         self.rev_challengeasset = util.hex_str_rev_hex_str(self.args.challengeasset)
 
         # test valid bid txid

--- a/guardnode/guardnode.py
+++ b/guardnode/guardnode.py
@@ -28,7 +28,6 @@ def parse_args():
     parser.add_argument('--bidpubkey', required=True, type=str, help="Guardnode winning bid public key")
 
     parser.add_argument('--challengehost', required=False, type=str, default=CHALLENGE_HOST_DEFAULT, help="Challenger host address")
-    parser.add_argument('--challengeasset', required=True, type=str, help="Challenge asset hash")
 
     return parser.parse_args()
 


### PR DESCRIPTION
moved demo to https://commerceblock.readthedocs.io/en/latest/guardnode/index.html and some other clean up:
- removed challengeasset argument, added `getChallengeAsset()`
- caught exception from no coordinator connection. Handle error nicely and display data that would have been sent. This is used also in running a demo without requiring coordinator connection